### PR TITLE
Fix abort sequences, add data collection to gui, and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ go/src/go.sum
 gui/.swp
 gui/vvv
 go/src/*.csv
+data/

--- a/config/sequences/reset.yml
+++ b/config/sequences/reset.yml
@@ -1,3 +1,8 @@
+# This setting indicates that this sequence will 
+# cancel and override any other currently running 
+# sequence.
+override: true
+
 steps:
   - action: CLOSE
     valve: V10

--- a/engine-computer/include/mach/device/device_manager.hpp
+++ b/engine-computer/include/mach/device/device_manager.hpp
@@ -42,6 +42,8 @@ class DeviceManager {
         void printDevices();
         bool isAborting();
         bool sleepOrAbort(std::chrono::milliseconds duration);
+        void enableAbortMode();
+        void disableAbortMode();
     
     private:
         DeviceManager() {}

--- a/engine-computer/include/mach/sequences/sequence.hpp
+++ b/engine-computer/include/mach/sequences/sequence.hpp
@@ -9,9 +9,7 @@ namespace mach {
     
 class Sequence {
     public:
-        Sequence(std::string name) : name(name), actions() {
-            this->override = name == "abort";
-        }
+        Sequence(std::string name) : name(name), actions() {}
 
         /**
          * @brief Adds an action to the sequence.
@@ -31,7 +29,7 @@ class Sequence {
             DeviceManager& deviceManager = DeviceManager::getInstance();
             for (auto& action : actions) {
                 if (deviceManager.isAborting() && !this->override) {
-                    spdlog::info("Aborting sequence '{}'", name);
+                    spdlog::info("Aborting sequence '{}'!", name);
                     return;
                 }
                 action->execute(this->override);
@@ -44,6 +42,10 @@ class Sequence {
 
         bool isOverride() {
             return override;
+        }
+
+        void setOverride(bool override) {
+            this->override = override;
         }
 
     private:

--- a/engine-computer/src/broadcast.cpp
+++ b/engine-computer/src/broadcast.cpp
@@ -19,6 +19,8 @@
     #include <unistd.h>
 #endif
 
+static std::string broadcastIp = "";
+
 #ifdef _WIN32
 static std::string getBroadcastAddress() {
     std::unique_ptr<IP_ADAPTER_ADDRESSES[]> adapter_addresses;
@@ -190,7 +192,7 @@ static void sendBroadcastMessage(int sock, const struct sockaddr_in& broadcastAd
         return;
     }
 
-    spdlog::info("MACH: Broadcast message sent.");
+    // spdlog::info("MACH: Broadcast message sent.");
 }
 
 static void closeSocket(int sock) {
@@ -212,8 +214,11 @@ static int broadcastServer() {
         return -1;
     }
 
-    std::string broadcastIp = getBroadcastAddress();
-    spdlog::info("MACH: Broadcasting server on broadcast IP: {}", broadcastIp);
+    std::string newBroadcastIp = getBroadcastAddress();
+    if (broadcastIp != newBroadcastIp) {
+        broadcastIp = newBroadcastIp;
+        spdlog::info("MACH: Broadcasting server on broadcast IP: {}", broadcastIp);
+    }
     struct sockaddr_in broadcastAddr = setupBroadcastAddress(broadcastIp);
     sendBroadcastMessage(sock, broadcastAddr);
 

--- a/engine-computer/src/device/device_manager.cpp
+++ b/engine-computer/src/device/device_manager.cpp
@@ -33,6 +33,10 @@ void mach::DeviceManager::startAllLabjackStreams() {
     std::thread(readLabjackStreams, std::ref(labJacks)).detach();
 }
 
+/**
+ * @deprecated This function was only used for GUI and may be 
+ * removed in the future.
+ */
 void mach::DeviceManager::abortAllLabjacks() {
     spdlog::info("MACH: Aborting all sequences.");
     abortFlag = true;
@@ -40,6 +44,10 @@ void mach::DeviceManager::abortAllLabjacks() {
     mach::Executor::getInstance().executeSequence("abort");
 }
 
+/**
+ * @deprecated This function was only used for GUI and may be 
+ * removed in the future.
+ */
 void mach::DeviceManager::disconnectAllLabjacks() {
     if (abortFlag) {
         spdlog::info("MACH: Already disconnected, skipping.");
@@ -55,6 +63,10 @@ void mach::DeviceManager::disconnectAllLabjacks() {
     }
 }
 
+/**
+ * @deprecated This function was only used for GUI and may be 
+ * removed in the future.
+ */
 void mach::DeviceManager::connectAllLabjacks() {
     spdlog::info("MACH: Connecting all labjacks.");
     for (auto& labJack : labJacks) {
@@ -62,6 +74,10 @@ void mach::DeviceManager::connectAllLabjacks() {
     }
 }
 
+/**
+ * @deprecated This function was only used for GUI and may be 
+ * removed in the future.
+ */
 void mach::DeviceManager::reconnectAllLabjacks() {
     this->disconnectAllLabjacks();
     spdlog::info("MACH: Reconnecting all labjacks.");
@@ -71,15 +87,33 @@ void mach::DeviceManager::reconnectAllLabjacks() {
     this->startAllLabjackStreams();
 }
 
+void mach::DeviceManager::enableAbortMode() {
+    spdlog::info("MACH: Enabling abort mode.");
+    abortFlag = true;
+    abortCondition.notify_all();
+}
+
+void mach::DeviceManager::disableAbortMode() {
+    spdlog::info("MACH: Disabling abort mode.");
+    abortFlag = false;
+}
+
 static void readLabjackStreams(std::list<std::shared_ptr<mach::LabJack>>& labJacks) {
     spdlog::info("MACH: Started reading LabJack streams.");
     while (true) { // TODO Abort?
+        long start = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
         for (auto& labJack : labJacks) {
             if (!labJack->readStream()) {
                 spdlog::info("MACH: Stopped reading all LabJack streams.");
                 return;
             }
         }
+        long end = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        if (end - start == 0) {
+            // Slow down man...
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+
     }
 }
 

--- a/engine-computer/src/executor.cpp
+++ b/engine-computer/src/executor.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <spdlog/spdlog.h>
 #include "mach/sequences/sequence_manager.hpp"
+#include "mach/device/device_manager.hpp"
 
 void mach::Executor::executeSequence(const std::string sequenceName) {
     std::shared_ptr<Sequence> sequence = SequenceManager::getInstance().getSequence(sequenceName);
@@ -11,15 +12,23 @@ void mach::Executor::executeSequence(const std::string sequenceName) {
         return;
     }
 
-    if (!sequence->isOverride() && executing.exchange(true, std::memory_order_acq_rel)) {
-        spdlog::warn("MACH: Skipped executing sequence {}, another sequence is already being executed.", sequenceName);
-        return;
+    if (executing.exchange(true, std::memory_order_acq_rel)) {
+        if (!sequence->isOverride()) {
+            spdlog::warn("MACH: Skipped executing sequence {}, another sequence is already being executed.", sequenceName);
+            return;
+        }
+        DeviceManager::getInstance().enableAbortMode();
     }
 
     std::thread([this, sequence]() {
         spdlog::info("MACH: Executing sequence {}.", sequence->getName());
         sequence->execute();
         spdlog::info("MACH: Finished sequence {}.", sequence->getName());
+        // If this sequence was an abort, disable the abort mode after 5 seconds.
+        if (sequence->isOverride()) {
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+            DeviceManager::getInstance().disableAbortMode();
+        }
         this->executing.store(false, std::memory_order_release);
     }).detach();
 }

--- a/engine-computer/src/grpc_client.cpp
+++ b/engine-computer/src/grpc_client.cpp
@@ -120,8 +120,8 @@ void grpcStartClient(int argc, char **argv) {
     // the argument "--target=" which is the only expected argument.
     std::string target_str = absl::GetFlag(FLAGS_ip);
 
-    std::thread(startCommandStream, target_str).detach(); // TODO
-    std::thread(startSensorDataStream, target_str).detach(); // TODO
+    std::thread(startCommandStream, target_str).detach();
+    std::thread(startSensorDataStream, target_str).detach();
 
     // Start broadcasting the server to the network.
     startBroadcastingServer();

--- a/engine-computer/src/labjack.cpp
+++ b/engine-computer/src/labjack.cpp
@@ -103,8 +103,6 @@ bool mach::LabJack::readStream() {
 
     for (int i = 0; i < sensors.size(); i++) {
         // Update state internally and in data packet.
-        // sensors[i]->updateValue(data[i]);
-        // state[sensors[i]->getName()] = data[i];
         double value;
         if (sensors[i]->getThermocoupleType() == "") {
             LJM_eReadName(handle, sensors[i]->getPort().c_str(), &value);

--- a/engine-computer/src/sequences/sequence_parser.cpp
+++ b/engine-computer/src/sequences/sequence_parser.cpp
@@ -38,6 +38,11 @@ static void parseSequence(std::string file) {
     spdlog::info("MACH: Parsing sequence from file '{}.yml'", sequenceName);
 
     ActionFactory& actionFactory = ActionFactory::getInstance();
+
+    YAML::Node override = config["override"];
+    if (override) {
+        sequence->setOverride(override.as<bool>());
+    }
     
     YAML::Node steps = config["steps"];
     for (YAML::const_iterator it = steps.begin(); it != steps.end(); it++) {

--- a/go/src/tcp/server.go
+++ b/go/src/tcp/server.go
@@ -2,7 +2,6 @@ package tcp
 
 import (
 	"bufio"
-	"fmt"
 	"log"
 	"net"
 	"strings"
@@ -49,7 +48,6 @@ func (s *TCPServer) handleConnection(conn net.Conn) {
 			break
 		}
 		msg = strings.TrimSpace(msg)
-		fmt.Println(msg)
 
 		cmd := &messages.SequenceCommand{
 			Sequence: msg,

--- a/gui/main.py
+++ b/gui/main.py
@@ -6,6 +6,7 @@ import threading
 import socket
 import json
 import ttkbootstrap as ttk
+import time
  
 # Constants
 ORIGINAL_WINDOW_WIDTH = 1280
@@ -72,14 +73,9 @@ progress_bar_positions = {
     "lc": (1159, 34, "horizontal", 1000)
 }
 
-sequence_positions = {
-    "reset": (25, 650),
-    "ignition": (95, 650),
-    "ematch_test": (165, 650),
-    "oxidizer": (235, 650),
-    "alternate_oxidizer": (305, 650),
-    "cold_flow": (375, 650),
-}
+sequences_start_position = (50, 600)
+sequences_max_width = 300
+sequences = ["reset", "ignition", "ematch_test", "oxidizer", "alternate_oxidizer", "cold_flow"]
 
 # Scaled button positions
 scaled_button_positions = {key: scale_position(x, y, SCALE_X, SCALE_Y) for key, (x, y) in button_positions.items()}
@@ -89,9 +85,6 @@ scaled_progress_bar_positions = {
     key: scale_progress_bar(x, y, orientation, length, SCALE_X, SCALE_Y)
     for key, (x, y, orientation, length) in progress_bar_positions.items()
 }
-
-# Scaled sequence positions
-scaled_sequence_positions = {key: scale_position(x, y, SCALE_X, SCALE_Y) for key, (x, y) in sequence_positions.items()}
 
 class GUIApp:
     def __init__(self, root):
@@ -169,6 +162,40 @@ class GUIApp:
             anchor="center",
             justify="center",
         )
+        # Style for labels
+        style.configure(
+            "TLabel",
+            font=("Helvetica", 12),
+            background="white",
+            foreground="black",
+            anchor="center",
+            justify="center",
+        )
+        
+        # Place data collection label
+        (x, y) = scale_size(250, 50 - 25, SCALE_X, SCALE_Y)
+        ttk.Label(self.root, text="Data Collection", style="TLabel").place(x=x, y=y)
+        
+        # Create data start and end buttons
+        scaled_x, scaled_y = scale_position(250, 50, SCALE_X, SCALE_Y)
+        scaled_width, scaled_height = scale_size(100, 25, SCALE_X, SCALE_Y)
+        start_data_btn = ttk.Button(
+            self.root,
+            text="Start Recording",
+            style="Open.TButton",
+            command=lambda: self.send_message("go:start_data\n"),
+        )
+        start_data_btn.place(x=scaled_x, y=scaled_y, width=scaled_width, height=scaled_height)
+        
+        scaled_x, scaled_y = scale_position(250, 85, SCALE_X, SCALE_Y)
+        scaled_width, scaled_height = scale_size(100, 25, SCALE_X, SCALE_Y)
+        start_data_btn = ttk.Button(
+            self.root,
+            text="Stop Recording",
+            style="Close.TButton",
+            command=lambda: self.send_message("go:stop_data\n"),
+        )
+        start_data_btn.place(x=scaled_x, y=scaled_y, width=scaled_width, height=scaled_height)
 
         # Creating buttons
         self.valve_buttons = {}
@@ -193,10 +220,19 @@ class GUIApp:
             )  # Adjusted to be vertically touching
 
             self.valve_buttons[valve] = (open_btn, close_btn)
+        
+        # Place sequence label
+        (x, y) = scale_size(sequences_start_position[0], sequences_start_position[1] - 25, SCALE_X, SCALE_Y)
+        ttk.Label(self.root, text="Sequences", style="TLabel").place(x=x, y=y)
 
+        # Place sequence buttons
         self.sequence_buttons = {}
         scaled_seq_width, scaled_seq_height = scale_size(70, 25, SCALE_X, SCALE_Y)
-        for button, (x, y) in scaled_sequence_positions.items():
+        scaled_max_width = int(sequences_max_width * SCALE_X)
+        (x_start, y_start) = scale_size(sequences_start_position[0], sequences_start_position[1], SCALE_X, SCALE_Y)
+        (x, y) = (x_start, y_start)
+        spacing = int(12 * SCALE_X)
+        for button in sequences:
             btn = ttk.Button(
                 self.root,
                 text=button,
@@ -205,6 +241,10 @@ class GUIApp:
             )
             btn.place(x=x, y=y, width=scaled_seq_width, height=scaled_seq_height)
             self.sequence_buttons[button] = btn
+            x += scaled_seq_width + spacing
+            if x >= scaled_max_width:
+                x = x_start
+                y += scaled_seq_height + spacing
 
         # Creating progress bars
         self.sensor_bars = {}
@@ -256,18 +296,37 @@ class GUIApp:
     def send_message(self, message):
         if hasattr(self, 'sock') and self.sock:
             try:
+                print(f"MACH: Sending message: {message.strip()}")
                 self.sock.sendall(message.encode('utf-8'))
             except ConnectionError as e:
-                print(f"Connection error: {e}")
+                print(f"MACH: Connection error: {e}")
 
-    def start_tcp_communication(self):
+    def _start_tcp_communication(self):
+        global engine_computer_ip
+        if not engine_computer_ip:
+            return
+        
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             print(f"MACH: Connecting to server at {engine_computer_ip}:{TCP_SERVER_PORT}.")
             self.sock.connect((engine_computer_ip, TCP_SERVER_PORT))
-            threading.Thread(target=self.tcp_communication_thread, daemon=True).start()
+            thread = threading.Thread(target=self.tcp_communication_thread, daemon=True)
+            thread.start()
+            thread.join()
+            
+            print(f"MACH: Lost connection to server, waiting for next broadcast.")
+            
         except ConnectionError as e:
-            print(f"Failed to connect to server: {e}")
+            print(f"MACH: Failed to connect to server: {e}, waiting for next broadcast.")
+            
+        finally:
+            self.sock.close()
+            self.sock = None
+            engine_computer_ip = None
+                
+
+    def start_tcp_communication(self):
+        threading.Thread(target=self._start_tcp_communication, daemon=True).start()
 
     def tcp_communication_thread(self):
         while True:
@@ -276,7 +335,7 @@ class GUIApp:
                 if data:
                     self.update_gui(data.decode("utf-8"))
             except ConnectionError as e:
-                print(f"Connection error: {e}")
+                print(f"MACH: Connection error: {e}, disconnecting!")
                 break
 
     def update_gui(self, data):
@@ -316,31 +375,41 @@ class GUIApp:
     
     def update_server_address(self, ip):
         global engine_computer_ip
-        if ip == engine_computer_ip:
+        if engine_computer_ip:
             return
-
+        
+        print(f"MACH: Found MACH Engine Computer at IP: {ip}.")
         engine_computer_ip = ip
         # Start TCP communication thread
         self.start_tcp_communication()
 
 
     def listen_for_broadcast(self, port):
-        # Create a UDP socket
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        # Enable the socket to receive broadcasts.
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        sock.bind(("", port))
+        sock = None
         
-        print(f"MACH: Listening for server broadcast messages on port {port}.")
-
         while True:
             # Receive broadcast.
-            data, addr = sock.recvfrom(1024)  # Buffer size is 1024 bytes
-            message = data.decode('utf-8')
-            if message == "MACH Engine Computer":
-                print(f"MACH: Found MACH Engine Computer at IP: {addr}.")
-                self.update_server_address(addr[0])
-                return
+            try:
+                if not sock:
+                    # Create a UDP socket
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    # Enable the socket to receive broadcasts.
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+                    sock.bind(("0.0.0.0", port))
+                    print(f"MACH: Listening for server broadcast messages on port {port}.")
+                    
+                data, addr = sock.recvfrom(1024)  # Buffer size is 1024 bytes
+                message = data.decode('utf-8')
+                if message == "MACH Engine Computer":
+                    self.update_server_address(addr[0])
+            except ConnectionError as e:
+                print(f"MACH: Broadcast connection error: {e}, retrying in 5 seconds.")
+                sock.close()
+                sock = None
+                time.sleep(5)
+                
+            except Exception as _:
+                continue
 
     def start_listening_thread(self, port):
         listener_thread = threading.Thread(target=self.listen_for_broadcast, args=(port,))


### PR DESCRIPTION
- Fix abort sequence not cancelling other sequences despite it executing in parallel.
- Add configuration flag such that any sequence can be an abort sequence.
- Add "start recording" and "stop recording" buttons to gui.
- Make gui automatically reconnect when losing connection.
- Stop spamming broadcast information on engine_computer.
- Move data csv files to the "data/" folder in root.
- GUI now reconnects automatically after losing connection.

gl @tk-stew 